### PR TITLE
allow passing list of fields for validation to save

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -25,7 +25,7 @@ define([
 		// handling to the property definitions objects.
 		var hasOwnPropertyInstance,
 			property = object.hasOwnProperty('_properties') && object._properties[key];
-		
+
 		hasOwnPropertyInstance = property;
 
 		if (!property) {
@@ -104,7 +104,7 @@ define([
 		//		A base class for modelled data objects.
 
 		//	schema: Object | dstore/Property
-		//		A hash map where the key corresponds to a property definition. 
+		//		A hash map where the key corresponds to a property definition.
 		//		This can be a string corresponding to a JavaScript
 		//		primitive values (string, number, boolean), a constructor, a
 		//		null (to allow any type), or a Property object with more advanced
@@ -112,7 +112,7 @@ define([
 		schema: {},
 
 		//	additionalProperties: boolean
-		//		This indicates whether properties are allowed that are not 
+		//		This indicates whether properties are allowed that are not
 		//		defined in the schema.
 		additionalProperties: true,
 
@@ -142,7 +142,7 @@ define([
 					values[key] = typeof defaultValue === 'function' ? defaultValue.call(this) : defaultValue;
 				}
 			}
-			
+
 		},
 
 		_setValues: function (values) {
@@ -156,14 +156,17 @@ define([
 		save: function (/*Object*/ options) {
 			//	summary:
 			//		Saves this object, calling put or add on the attached store.
-			//	options.skipValidation:
+			//	options.skipValidation: boolean?
 			//		Normally, validation is performed to ensure that the object
 			//		is not invalid before being stored. Set `skipValidation` to
 			//		true to skip it.
+			//	options.validateFields: string[]?
+			//		List of fields to pass to `validate` when only partially
+			//		validating during save.
 			//	returns: any
 
 			var object = this;
-			return when((options && options.skipValidation) ? true : this.validate(), function (isValid) {
+			return when((options && options.skipValidation) ? true : this.validate(options.validateFileds), function (isValid) {
 				if (!isValid) {
 					throw object.createValidationError(object.errors);
 				}
@@ -438,7 +441,7 @@ define([
 			//		If this is true, it won't call the listener for the current value,
 			//		just future updates. If this is true, it also won't return
 			//		a new reactive object
-			
+
 			var reactive;
 			if (typeof listener === 'string') {
 				// a property key was provided, use the Model's method
@@ -457,7 +460,7 @@ define([
 			var handle = this._addListener(function (value) {
 				var result = listener(value);
 				if (reactive) {
-					// TODO: once we have a real notification API again, call that, instead 
+					// TODO: once we have a real notification API again, call that, instead
 					// of requesting a change
 					reactive.put(result);
 				}
@@ -474,7 +477,7 @@ define([
 		//		Indicates whether or not to perform validation when properties
 		//		are modified.
 		//		This can provided immediate feedback and on the success
-		//		or failure of a property modification. And Invalid property 
+		//		or failure of a property modification. And Invalid property
 		//		values will be rejected. However, if you are
 		//		using asynchronous validation, invalid property values will still
 		//		be set.
@@ -624,7 +627,7 @@ define([
 				(this.type === typeof value))) {
 				errors.push(value + ' is not a ' + this.type);
 			}
-			
+
 			if (this.required && !(value != null && value !== '')) {
 				errors.push('required, and it was not present');
 			}


### PR DESCRIPTION
when calling `save`, it could be helpful to be able to pass the list of fields to pass to `validate`.  for example, a schema might define an `id` property that's required but when creating a new object the `id` is assigned by the server.  in that case, being able to validate all the other fields (rather than completely skipping validation with `options.skipValidation`) would be useful.

``` js
store.create(data).save({ validateFields: [ 'foo', 'bar' ] });
```

the PR will be trivial - i'll try to get to it soon.
